### PR TITLE
Tag modifiers

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -92,7 +92,7 @@ function tumblr3_theme_parse( $content ): string {
 	$blocks    = array_map( 'strtolower', array_keys( TUMBLR3_BLOCKS ) );
 	$lang      = array_map( 'strtolower', array_keys( TUMBLR3_LANG ) );
 	$options   = array_map( 'strtolower', array_keys( TUMBLR3_OPTIONS ) );
-	$modifiers = array_map( 'strtolower', array_keys( TUMBLR3_MODIFIERS ) );
+	$modifiers = array_map( 'strtolower', TUMBLR3_MODIFIERS );
 
 	// Capture each Tumblr Tag in the page and verify it against our arrays.
 	$content = preg_replace_callback(
@@ -142,7 +142,7 @@ function tumblr3_theme_parse( $content ): string {
 			 */
 			foreach ( $modifiers as $modifier ) {
 				if ( str_starts_with( $raw_tag, $modifier ) ) {
-					// Tag with a modifier at the front.
+					$raw_tag = strtolower ( substr( $raw_tag, strlen($modifier) ) );
 					//[tag_name modifier="RGB"]
 				}
 			}

--- a/functions.php
+++ b/functions.php
@@ -271,4 +271,4 @@ function tumblr3_handle_modifiers( $output, $tag, $attr ) {
 	}
 	return $output;
 }
-add_filter( 'tumblr3_shortcode_output', 'tumblr3_handle_modifiers', 10, 3 );
+add_filter( 'do_shortcode_tag', 'tumblr3_handle_modifiers', 10, 3 );

--- a/includes/tag-functions.php
+++ b/includes/tag-functions.php
@@ -200,8 +200,9 @@ add_shortcode( 'tag_avatarshape', 'tumblr3_tag_avatarshape' );
  *
  * @see https://www.tumblr.com/docs/en/custom_themes#basic_variables
  */
-function tumblr3_tag_backgroundcolor(): string {
-	return '#' . sanitize_hex_color_no_hash( get_theme_mod( 'background_color', '#fff' ) );
+function tumblr3_tag_backgroundcolor( $atts ): string {
+	$output = '#' . sanitize_hex_color_no_hash( get_theme_mod( 'background_color', '#fff' ) );
+	return apply_filters( 'tumblr3_shortcode_output', $output, 'tag_backgroundcolor', $atts );
 }
 add_shortcode( 'tag_backgroundcolor', 'tumblr3_tag_backgroundcolor' );
 
@@ -212,8 +213,9 @@ add_shortcode( 'tag_backgroundcolor', 'tumblr3_tag_backgroundcolor' );
  *
  * @see https://www.tumblr.com/docs/en/custom_themes#basic_variables
  */
-function tumblr3_tag_accentcolor(): string {
-	return '#' . sanitize_hex_color_no_hash( get_theme_mod( 'accent_color', '#0073aa' ) );
+function tumblr3_tag_accentcolor( $atts ): string {
+	$output = '#' . sanitize_hex_color_no_hash( get_theme_mod( 'accent_color', '#0073aa' ) );
+	return apply_filters( 'tumblr3_shortcode_output', $output, 'tag_accentcolor', $atts );
 }
 add_shortcode( 'tag_accentcolor', 'tumblr3_tag_accentcolor' );
 

--- a/includes/tag-functions.php
+++ b/includes/tag-functions.php
@@ -201,8 +201,7 @@ add_shortcode( 'tag_avatarshape', 'tumblr3_tag_avatarshape' );
  * @see https://www.tumblr.com/docs/en/custom_themes#basic_variables
  */
 function tumblr3_tag_backgroundcolor( $atts ): string {
-	$output = '#' . sanitize_hex_color_no_hash( get_theme_mod( 'background_color', '#fff' ) );
-	return apply_filters( 'tumblr3_shortcode_output', $output, 'tag_backgroundcolor', $atts );
+	return '#' . sanitize_hex_color_no_hash( get_theme_mod( 'background_color', '#fff' ) );
 }
 add_shortcode( 'tag_backgroundcolor', 'tumblr3_tag_backgroundcolor' );
 
@@ -214,8 +213,7 @@ add_shortcode( 'tag_backgroundcolor', 'tumblr3_tag_backgroundcolor' );
  * @see https://www.tumblr.com/docs/en/custom_themes#basic_variables
  */
 function tumblr3_tag_accentcolor( $atts ): string {
-	$output = '#' . sanitize_hex_color_no_hash( get_theme_mod( 'accent_color', '#0073aa' ) );
-	return apply_filters( 'tumblr3_shortcode_output', $output, 'tag_accentcolor', $atts );
+	return '#' . sanitize_hex_color_no_hash( get_theme_mod( 'accent_color', '#0073aa' ) );
 }
 add_shortcode( 'tag_accentcolor', 'tumblr3_tag_accentcolor' );
 

--- a/includes/tag-functions.php
+++ b/includes/tag-functions.php
@@ -200,7 +200,7 @@ add_shortcode( 'tag_avatarshape', 'tumblr3_tag_avatarshape' );
  *
  * @see https://www.tumblr.com/docs/en/custom_themes#basic_variables
  */
-function tumblr3_tag_backgroundcolor( $atts ): string {
+function tumblr3_tag_backgroundcolor(): string {
 	return '#' . sanitize_hex_color_no_hash( get_theme_mod( 'background_color', '#fff' ) );
 }
 add_shortcode( 'tag_backgroundcolor', 'tumblr3_tag_backgroundcolor' );
@@ -212,7 +212,7 @@ add_shortcode( 'tag_backgroundcolor', 'tumblr3_tag_backgroundcolor' );
  *
  * @see https://www.tumblr.com/docs/en/custom_themes#basic_variables
  */
-function tumblr3_tag_accentcolor( $atts ): string {
+function tumblr3_tag_accentcolor(): string {
 	return '#' . sanitize_hex_color_no_hash( get_theme_mod( 'accent_color', '#0073aa' ) );
 }
 add_shortcode( 'tag_accentcolor', 'tumblr3_tag_accentcolor' );


### PR DESCRIPTION
### Summary

Able to handle Tumblr tag variants:

<img width="641" alt="Screenshot 2024-10-11 at 17 13 38" src="https://github.com/user-attachments/assets/dc86482a-e558-4eb8-8f58-6a5a5b1da713">

See https://www.tumblr.com/docs/en/custom_themes

### Solution

First, when parsing the HTML we check for Tag modifiers from the list of accepted tag variants.

We then insert the modifier into shortcode attributes.

And finally using [do_shortcode_tag filter](https://developer.wordpress.org/reference/hooks/do_shortcode_tag/) we modify the shortcode output, handling the modifier attribute depending on the modifier type.

Note: This doesn't do any sanity checking, for example you can append RGB to a non color tag and it will fail. Can be improved in future changes.

### Testing steps

**Plaintext:**

**Javascript:**

**Javascript Plaintext:**

**URLEncoded:**

Converts the output to a URLEncoded string

1. Add the following HTML to your theme: ```My accent color: {RGBAccentColor}```

**RGB:**

Converts HEX output to RGB, test steps:

1. Add the following HTML to your theme: ```My accent color: {RGBAccentColor}```
2. Set the Accent Color in the theme Color options
3. Publish Inspect the HTML, search for "My accent color"
4. Expected: The hex value has been converted to RGB values: #287504 -> 40, 117, 4

### Reviewing tips

🧁 Request a review to team chrysalis to assign a random team member.

🔄 Feel free to ping the team name again to "re-roll" or add another team member.

🚀 For now there is no requirement on getting review approvals before merging.
