### PR TITLE
Chat Post format

### DIFF
--- a/includes/tag-functions.php
+++ b/includes/tag-functions.php
@@ -505,17 +505,43 @@ add_shortcode( 'tag_embedurl', 'tumblr3_tag_url' );
 
 /**
  * Typically a page title, used in a page loop e.g navigation.
- *
- * @todo This tag is also used in legacy chat posts.
+ * Also used as the Chat label for legacy chat posts.
  *
  * @return string
  *
  * @see https://www.tumblr.com/docs/en/custom_themes#basic_variables
+ * @see https://www.tumblr.com/docs/en/custom_themes#chat-posts
  */
 function tumblr3_tag_label(): string {
-	return wp_kses_post( get_the_title() );
+	$context = tumblr3_get_parse_context();
+
+	if ( ! isset( $context['chat']['label'] ) ) {
+		// By default, return the page title.
+		return wp_kses_post( get_the_title() );
+	}
+
+	return $context['chat']['label'];
 }
 add_shortcode( 'tag_label', 'tumblr3_tag_label' );
+
+/**
+ * Current line of a legacy chat post.
+ *
+ * @return string
+ *
+ * @see https://www.tumblr.com/docs/en/custom_themes#chat-posts
+ */
+function tumblr3_tag_line(): string {
+	$context = tumblr3_get_parse_context();
+
+	// Check if we are in a chat context.
+	if ( ! isset( $context['chat']['line'] ) ) {
+		return '';
+	}
+
+	return $context['chat']['line'];
+}
+add_shortcode( 'tag_line', 'tumblr3_tag_line' );
 
 /**
  * Tagsasclasses outputs the tags of a post as HTML-safe classes.


### PR DESCRIPTION
### Summary

A very naive implementation of the chat post format

### Solution

Handles the following tags from https://www.tumblr.com/docs/en/custom_themes#chat-posts

{block:lines} {/block:lines}
{block:label} {/block:label} 
{label} - in the context of chat
{line}

Tested only within the context of the vision theme.

We expect the following setup:

A post set to Chat format
A list of Paragraph block types
An Optional ':' to mark the chat label on any paragraph (takes the first colon)

### Testing steps

Suggest testing with the vision theme

1. Create a post
2. Set it to Chat format
3. Add a paragraph Hagrid: You're a wizard arry!
4. Add another paragraph Harry: A what?
5. Publish

View post - it should render the chat labels 'Hagrid:' and 'Harry:' in bold

### Reviewing tips

🧁 Request a review to team CupcakeLabs to assign a random team member.

🔄 Feel free to ping the team name again to "re-roll" or add another team member.

🚀 For now there is no requirement on getting review approvals before merging.
