### PR TITLE
Standardize line endings in lang

### DIFF
--- a/includes/tag-functions.php
+++ b/includes/tag-functions.php
@@ -42,7 +42,8 @@ function tumblr3_tag_lang( $atts ): string {
 
 	// If a value is provided, return it.
 	if ( ! empty( $atts['value'] ) ) {
-		return $atts['value'];
+		// Standardize any line endings in the translation to \n.
+		return preg_replace( '/\R/', '\n', $atts['value'] );
 	}
 
 	// Find keywords in the key and add them to the stack.


### PR DESCRIPTION
### Summary

The Tumblr Official theme is outputting malformed javascript via the lang tag:

```
Optica.NO_POSTS_VARIANTS = [
           "This Tumblr hasn't made any posts.",
           "This silly Tumblr hasn't posted anything yet.",
           "This Tumblr is cool, but empty.",
           "This Tumblr is content-free.",
           "This minimalist Tumblr has no posts.",
           "Meditate for a while on this empty Tumblr.",
           "Posts? Nah.",
           "This Tumblr has hardly any posts. 
None at all, in fact.",
           "This Tumblr hasn't posted anything."
       ];
```

I'm guessing there's some OS line ending differences in the language files, this PR should fix it to output:

```
Optica.NO_POSTS_VARIANTS = [
                "This Tumblr hasn't made any posts.",
                "This silly Tumblr hasn't posted anything yet.",
                "This Tumblr is cool, but empty.",
                "This Tumblr is content-free.",
                "This minimalist Tumblr has no posts.",
                "Meditate for a while on this empty Tumblr.",
                "Posts? Nah.",
                "This Tumblr has hardly any posts. \nNone at all, in fact.",
                "This Tumblr hasn't posted anything."
            ];
```

### Solution

Replace line endings in the lang value with a standard /n, this is in line with how it's seen on the blog network with the Official theme.

### Testing steps

1. Copy Tumblr official theme HTML into your custom theme HTML
2. View site and copy HTML into a text editor
3. Confirm the line "This Tumblr has hardly any posts. \nNone at all, in fact.", is on a single line

### Reviewing tips

🧁 Request a review to team CupcakeLabs to assign a random team member.

🔄 Feel free to ping the team name again to "re-roll" or add another team member.

🚀 For now there is no requirement on getting review approvals before merging.
