### PR TITLE
cache invalidation

### DIFF
--- a/src/ThemeGarden.php
+++ b/src/ThemeGarden.php
@@ -134,7 +134,7 @@ class ThemeGarden {
 			return;
 		}
 
-		$response = wp_remote_get( self::THEME_GARDEN_ENDPOINT . '/theme/' . esc_attr( $_GET['activate_tumblr_theme'] ) );
+		$response = wp_remote_get( self::THEME_GARDEN_ENDPOINT . '/theme/' . esc_attr( $_GET['activate_tumblr_theme'] ) . '?time=' . time() );
 		$status   = wp_remote_retrieve_response_code( $response );
 
 		if ( 200 !== $status ) {

--- a/src/ThemeGarden.php
+++ b/src/ThemeGarden.php
@@ -134,6 +134,8 @@ class ThemeGarden {
 			return;
 		}
 
+		// During development, we don't want to be so limited by cache. So we'll send a cache invalidator to every request.
+		// TODO: remove once we are confident that api response will be stable.
 		$response = wp_remote_get( self::THEME_GARDEN_ENDPOINT . '/theme/' . esc_attr( $_GET['activate_tumblr_theme'] ) . '?time=' . time() );
 		$status   = wp_remote_retrieve_response_code( $response );
 


### PR DESCRIPTION
### Summary

We shouldn't rely so heavily on cache during development time, when the api response changes sometimes.