### PR TITLE
Add Show Header Image toggle

### DIFF
--- a/includes/block-functions.php
+++ b/includes/block-functions.php
@@ -635,12 +635,14 @@ add_shortcode( 'block_haspages', 'tumblr3_block_haspages' );
  * @return string
  */
 function tumblr3_block_showheaderimage( $atts, $content = '' ): string {
-	return ( 'remove-header' !== get_theme_mod( 'header_image', 'remove-header' ) ) ? tumblr3_do_shortcode( $content ) : '';
+	return ( get_theme_mod( 'show_header_image', true ) &&
+		'remove-header' !== get_theme_mod( 'header_image', 'remove-header' ) )
+		? tumblr3_do_shortcode( $content ) : '';
 }
 add_shortcode( 'block_showheaderimage', 'tumblr3_block_showheaderimage' );
 
 /**
- * Rendered if you have "Show header image" disabled.
+ * Rendered if you have     "Show header image" disabled.
  *
  * @param array  $atts    The attributes of the shortcode.
  * @param string $content The content of the shortcode.
@@ -648,7 +650,9 @@ add_shortcode( 'block_showheaderimage', 'tumblr3_block_showheaderimage' );
  * @return string
  */
 function tumblr3_block_hideheaderimage( $atts, $content = '' ): string {
-	return ( 'remove-header' === get_theme_mod( 'header_image', 'remove-header' ) ) ? tumblr3_do_shortcode( $content ) : '';
+	return ( ! get_theme_mod( 'show_header_image', true ) ||
+		'remove-header' === get_theme_mod( 'header_image', 'remove-header' ) )
+		? tumblr3_do_shortcode( $content ) : '';
 }
 add_shortcode( 'block_hideheaderimage', 'tumblr3_block_hideheaderimage' );
 

--- a/src/Customizer.php
+++ b/src/Customizer.php
@@ -228,6 +228,25 @@ class Customizer {
 			)
 		);
 
+		// Add a show header image checkbox control.
+		$wp_customize->add_setting(
+			'show_header_image',
+			array(
+				'default'           => 'yes',
+				'sanitize_callback' => 'sanitize_text_field',
+			)
+		);
+
+		$wp_customize->add_control(
+			'show_header_image',
+			array(
+				'label'    => __( 'Show Header Image', 'tumblr3' ),
+				'section'  => 'tumblr3_boolean',
+				'type'     => 'checkbox',
+				'priority' => 10,
+			)
+		);
+
 		// Add a stretch header image checkbox control.
 		$wp_customize->add_setting(
 			'stretch_header_image',


### PR DESCRIPTION
### Summary

The current behaviour will set ShowHeaderImage to true if a header image is uploaded. Tumblr however has a separate setting show Show Header Image, allowing a blog to have an image uploaded but set to fals

### Solution

Separated logic for hiding the header image, added a new boolean control "Show Header Image"

### Testing steps

1. Select a theme that support header images such as Vision
2. Go to site Customise
3. Upload a header image
4. From boolean option toggle Show Header Image on/off to see the header image be hidden/shown

### Reviewing tips

🧁 Request a review to team CupcakeLabs to assign a random team member.

🔄 Feel free to ping the team name again to "re-roll" or add another team member.

🚀 For now there is no requirement on getting review approvals before merging.
