### PR TITLE
Feature/jetpack integration

### DIFF
--- a/includes/tumblr-theme-language/missing-tags.php
+++ b/includes/tumblr-theme-language/missing-tags.php
@@ -58,7 +58,6 @@ return array(
 	'tag_asklabel',
 	'tag_answer',
 	'tag_replies',
-	'tag_likebutton',
 	'tag_likes',
 	'tag_reblogparentname',
 	'tag_reblogparenttitle',

--- a/includes/tumblr-theme-language/tags.php
+++ b/includes/tumblr-theme-language/tags.php
@@ -4,7 +4,6 @@
  *
  * @package Tumblr3
  */
-
 defined( 'ABSPATH' ) || exit;
 
 return array(
@@ -282,4 +281,5 @@ return array(
 	'AudioPlayerBlack',
 	'AudioPlayerGrey',
 	'PostTypeNoun',
+	'LikeButton',
 );

--- a/src/Customizer.php
+++ b/src/Customizer.php
@@ -77,27 +77,6 @@ class Customizer {
 				'priority' => 10,
 			)
 		);
-
-		// Add a "use tumblr theme" checkbox.
-		$wp_customize->add_setting(
-			'tumblr3_use_theme',
-			array(
-				'type'              => 'option',
-				'capability'        => 'edit_theme_options',
-				'default'           => 0,
-				'sanitize_callback' => 'sanitize_text_field',
-			)
-		);
-
-		$wp_customize->add_control(
-			'tumblr3_use_theme',
-			array(
-				'label'    => __( 'Use Tumblr Theme?', 'tumblr3' ),
-				'section'  => 'tumblr3_html',
-				'type'     => 'checkbox',
-				'priority' => 5,
-			)
-		);
 	}
 
 	/**

--- a/theme/tumblr3/index.php
+++ b/theme/tumblr3/index.php
@@ -24,6 +24,9 @@ wp_head();
 $tumblr3_head = ob_get_contents();
 ob_end_clean();
 
+// Parse and potentially store the parsed theme HTML.
+$tumblr3_theme = apply_filters( 'tumblr3_theme_output', $tumblr3_theme );
+
 /**
  * Capture wp_footer output.
  *
@@ -33,9 +36,6 @@ ob_start();
 wp_footer();
 $tumblr3_footer = ob_get_contents();
 ob_end_clean();
-
-// Parse and potentially store the parsed theme HTML.
-$tumblr3_theme = apply_filters( 'tumblr3_theme_output', $tumblr3_theme );
 
 // Add the head and footer to the theme.
 $tumblr3_theme = str_replace( '</head>', $tumblr3_head . '</head>', $tumblr3_theme );


### PR DESCRIPTION
### Summary

- Moves `wp_footer()` call in the theme `index.php` file for better compatibility with Jetpack
- Adds a basic reblog URL.
- Rudimentary like button implementation: more work needed here.
- Removes `use tumblr theme` checkbox from the customizer.