### PR TITLE
fix: undefined pinned post key in lang array

### DIFF
--- a/includes/tag-functions.php
+++ b/includes/tag-functions.php
@@ -653,7 +653,7 @@ add_shortcode( 'tag_tagsasclasses', 'ttgarden_tagsasclasses' );
  * @see https://www.tumblr.com/docs/en/custom_themes#basic_variables
  */
 function ttgarden_tag_pinnedpostlabel(): string {
-	return esc_html( TTGARDEN_LANG['lang:Pinned Post'] );
+	return esc_html( TTGARDEN_LANG['lang:pinned post'] );
 }
 add_shortcode( 'tag_pinnedpostlabel', 'ttgarden_tag_pinnedpostlabel' );
 


### PR DESCRIPTION
### Summary

Fixes warning "Warning: Undefined array key "lang:Pinned Post" in /var/www/html/wp-content/plugins/tumblr-theme-garden/includes/tag-functions.php on line 656"

and missing text translation next to the Pin icon

Before:

<img width="2240" alt="Screenshot 2024-12-18 at 12 42 31" src="https://github.com/user-attachments/assets/18b08abf-308e-4601-9458-6f71878d386a" />

After:
<img width="2069" alt="Screenshot 2024-12-18 at 12 44 06" src="https://github.com/user-attachments/assets/3afba8d9-0dae-4865-84ec-119026760207" />

### Solution

Changes key to lower case, as TTGARDEN_LANG is defined as:

`define( 'TTGARDEN_LANG', array_change_key_case( $lang, CASE_LOWER ) );`

### Testing steps

1. If you do not have any pinned posts in content, make a post sticky by adding the "sticky" tag to a post
2. Activate Tumblr Official theme
3. Check pinned post says "Pinned Post" rather than just the pin icon

### Reviewing tips

🧁 Request a review to team CupcakeLabs to assign a random team member.

🔄 Feel free to ping the team name again to "re-roll" or add another team member.

🚀 For now there is no requirement on getting review approvals before merging.
