### PR TITLE
Fix live preview

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -193,6 +193,23 @@ function ttgarden_comment_markup( $comment, $args ): void {
 }
 
 /**
+ * Get the Tumblr theme HTML content.
+ *
+ * @return string The HTML content.
+ */
+function ttgarden_get_theme_html(): string {
+	global $wp_filesystem;
+	require_once ABSPATH . 'wp-admin/includes/file.php';
+
+	if ( ! WP_Filesystem() ) {
+		wp_die( 'Failed to access the filesystem.' );
+	}
+
+	// Get the HTML content from our templates/index.html file.
+	return $wp_filesystem->get_contents( get_template_directory() . '/templates/index.html' );
+}
+
+/**
  * This is the main output function for the plugin.
  * This function pulls in the Tumblr theme content and then processes it.
  *
@@ -200,7 +217,7 @@ function ttgarden_comment_markup( $comment, $args ): void {
  */
 function ttgarden_page_output(): void {
 	// Get the HTML content from the themes template part.
-	$content = file_get_contents( get_template_directory() . '/templates/index.html' );
+	$content = ttgarden_get_theme_html();
 
 	// Shortcodes don't currently have a doing_shortcode() or similar.
 	// So we need a global to track the context.

--- a/src/Customizer.php
+++ b/src/Customizer.php
@@ -378,16 +378,8 @@ class Customizer {
 		);
 
 		// Parse the theme HTML.
-		global $wp_filesystem;
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-
-		if ( ! WP_Filesystem() ) {
-			wp_die( 'Failed to access the filesystem.' );
-		}
-
 		// Get the HTML content from our templates/index.html file.
-		$theme_html = $wp_filesystem->get_contents( get_template_directory() . '/templates/index.html' );
-
+		$theme_html     = ttgarden_get_theme_html();
 		$processor      = new \WP_HTML_Tag_Processor( $theme_html );
 		$select_options = array();
 

--- a/src/FeatureSniffer.php
+++ b/src/FeatureSniffer.php
@@ -98,15 +98,7 @@ array(
 		if ( '' !== $this->html ) {
 			$html = strtolower( $this->html );
 		} else {
-			global $wp_filesystem;
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-
-			if ( ! WP_Filesystem() ) {
-				wp_die( 'Failed to access the filesystem.' );
-			}
-
-			// Get the HTML content from our templates/index.html file.
-			$html = strtolower( $wp_filesystem->get_contents( get_template_directory() . '/templates/index.html' ) );
+			$html = strtolower( ttgarden_get_theme_html() );
 		}
 
 		// Check each unsupported feature.

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -46,7 +46,7 @@ class Hooks {
 
 		add_filter( 'wp_prepare_themes_for_js', array( $this, 'prepare_themes_for_js' ) );
 
-		// Only run these if the TumblrThemeGarden theme is active.
+		// Only run these if the TumblrThemeGarden theme is active or we're in a customizer preview.
 		if ( $this->is_ttgarden_active ) {
 			add_filter( 'template_include', array( $this, 'template_include' ) );
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -28,6 +28,16 @@ class Plugin {
 	public bool $ttgarden_active = false;
 
 	/**
+	 * The customize preview status.
+	 *
+	 * @since   1.0.0
+	 * @version 1.0.0
+	 *
+	 * @var     bool
+	 */
+	public bool $customize_preview = false;
+
+	/**
 	 * The hooks component.
 	 *
 	 * @since   1.0.0
@@ -138,12 +148,14 @@ class Plugin {
 	 * @return  void
 	 */
 	public function initialize(): void {
-		$theme      = wp_get_theme();
-		$theme_tags = $theme->get( 'Tags' );
-		$is_tumblr_theme_active = is_array($theme_tags) && in_array('tumblr-theme', $theme_tags, true);
-		$is_tumblr_theme_live_preview = isset($_GET['theme']) && str_contains($_GET['theme'], 'tumblr');
+		$theme                  = wp_get_theme();
+		$theme_tags             = $theme->get( 'Tags' );
+		$is_tumblr_theme_active = is_array( $theme_tags ) && in_array( 'tumblr-theme', $theme_tags, true );
 
-		$this->ttgarden_active = $is_tumblr_theme_active || $is_tumblr_theme_live_preview;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Get is only checked, not consumed.
+		$theme_slug              = isset( $_GET['theme'] ) ? sanitize_text_field( wp_unslash( $_GET['theme'] ) ) : '';
+		$this->customize_preview = is_customize_preview() && str_contains( $theme_slug, 'tumblr' );
+		$this->ttgarden_active   = $is_tumblr_theme_active || $this->customize_preview;
 
 		// Setup all plugin hooks.
 		$this->hooks = new Hooks();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -140,8 +140,10 @@ class Plugin {
 	public function initialize(): void {
 		$theme      = wp_get_theme();
 		$theme_tags = $theme->get( 'Tags' );
+		$is_tumblr_theme_active = is_array($theme_tags) && in_array('tumblr-theme', $theme_tags, true);
+		$is_tumblr_theme_live_preview = isset($_GET['theme']) && str_contains($_GET['theme'], 'tumblr');
 
-		$this->ttgarden_active = ( is_array( $theme_tags ) ) ? in_array( 'tumblr-theme', $theme_tags, true ) : false;
+		$this->ttgarden_active = $is_tumblr_theme_active || $is_tumblr_theme_live_preview;
 
 		// Setup all plugin hooks.
 		$this->hooks = new Hooks();

--- a/tumblr-theme-garden.php
+++ b/tumblr-theme-garden.php
@@ -77,4 +77,4 @@ if ( ! is_file( TTGARDEN_PATH . '/vendor/autoload.php' ) ) {
 require_once TTGARDEN_PATH . '/vendor/autoload.php';
 
 require_once TTGARDEN_PATH . 'functions.php';
-add_action( 'plugins_loaded', array( ttgarden_get_plugin_instance(), 'initialize' ) );
+add_action( 'after_setup_theme', array( ttgarden_get_plugin_instance(), 'initialize' ) );


### PR DESCRIPTION
### Summary

The live preview works great when the current theme is a Tumblr theme. However, the live preview will break if the current theme is not a Tumblr theme.

To reproduce bug:

1. Go to the installed themes page.
2. Ensure you have a Tumblr theme downloaded.
3. Ensure active theme is not a Tumblr theme.
4. Click the Live Preview button on a Tumblr theme.
5. The customizer will load up previewing a theme with unparsed blocks.

![Screenshot 2025-01-09 at 4 18 31 PM](https://github.com/user-attachments/assets/daa29833-c6f9-411b-897c-45607ab79705)

